### PR TITLE
#29.1 - 회원계정 도메인 PK를 userId로 변경

### DIFF
--- a/board/src/main/java/com/marathon/board/domain/Article.java
+++ b/board/src/main/java/com/marathon/board/domain/Article.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
@@ -42,7 +43,8 @@ public class Article extends AuditingFields {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Setter @ManyToOne(optional = false) private UserAccount userAccount; // 유저 정보 (ID)
+  // JoinColumn을 사용하여 외래키(FK) 칼럼을 지정하고, 엔티티간의 관계를 설정
+  @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
 
   @Setter
   @Column(nullable = false)

--- a/board/src/main/java/com/marathon/board/domain/ArticleComment.java
+++ b/board/src/main/java/com/marathon/board/domain/ArticleComment.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -42,6 +43,7 @@ public class ArticleComment extends AuditingFields {
 
   @Setter
   @ManyToOne(optional = false)
+  @JoinColumn( name = "userId") // JoinColumn을 사용하여 외래키(FK) 칼럼을 지정하고, 엔티티간의 관계를 설정
   private UserAccount userAccount; // 유저 정보 (ID)
 
   @Setter

--- a/board/src/main/java/com/marathon/board/domain/UserAccount.java
+++ b/board/src/main/java/com/marathon/board/domain/UserAccount.java
@@ -16,18 +16,17 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 @Table(indexes = {
-    @Index(columnList = "userId", unique = true),
     @Index(columnList = "email", unique = true),
     @Index(columnList = "createdAt"),
     @Index(columnList = "createdBy")
 })
 @Entity
 public class UserAccount extends AuditingFields {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long Id;
 
-    @Setter
+    /**
+     * 2023.06.17 userId를 회원계정 도메인의 PK로 설정.
+     * */
+    @Id
     @Column(length = 50)
     private String userId;
 
@@ -62,13 +61,13 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
-        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
+        if (!(o instanceof UserAccount userAccount)) return false;
+        return userId != null && userId.equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getUserId());
+        return Objects.hash(userId);
     }
 
 }

--- a/board/src/main/java/com/marathon/board/dto/UserAccountDto.java
+++ b/board/src/main/java/com/marathon/board/dto/UserAccountDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import com.marathon.board.domain.UserAccount;
 
 public record UserAccountDto(
-    Long id,
     String userId,
     String userPassword,
     String email,
@@ -16,13 +15,12 @@ public record UserAccountDto(
     LocalDateTime modifiedAt,
     String modifiedBy
 ) {
-    public static UserAccountDto of(Long id, String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(id, userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
     public static UserAccountDto from(UserAccount entity) {
         return new UserAccountDto(
-            entity.getId(),
             entity.getUserId(),
             entity.getUserPassword(),
             entity.getEmail(),

--- a/board/src/test/java/com/marathon/board/controller/ArticleControllerTest.java
+++ b/board/src/test/java/com/marathon/board/controller/ArticleControllerTest.java
@@ -190,7 +190,7 @@ class ArticleControllerTest {
     }
 
     private UserAccountDto createUserAccountDto(){
-        return UserAccountDto.of(1L,
+        return UserAccountDto.of(
             "Jake",
             "pw"
             ,"wow@gmail.com",

--- a/board/src/test/java/com/marathon/board/service/ArticleCommentServiceTest.java
+++ b/board/src/test/java/com/marathon/board/service/ArticleCommentServiceTest.java
@@ -146,7 +146,6 @@ class ArticleCommentServiceTest {
 
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
-            1L,
             "uno",
             "password",
             "uno@mail.com",

--- a/board/src/test/java/com/marathon/board/service/ArticleServiceTest.java
+++ b/board/src/test/java/com/marathon/board/service/ArticleServiceTest.java
@@ -286,7 +286,6 @@ class ArticleServiceTest {
 
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
-            1L,
             "uno",
             "password",
             "uno@mail.com",


### PR DESCRIPTION
변경 전 : UserAccount 도메인의 PK는 자동생성되는 id
변경 후 : UserAccount 도메인의 PK는 입력받는 userId
PK를 변경함에 따라 게시글, 댓글의 userId 영향 받는 것들 변경.